### PR TITLE
Auto-registering with multiple implementations

### DIFF
--- a/Sources/Templates/AutoRegistering.swift
+++ b/Sources/Templates/AutoRegistering.swift
@@ -29,7 +29,7 @@ enum AutoRegistering {
                     let registrationValue = nameAndValue[1]
                     lines.append("\(registrationName).register { \(registrationValue) }".indent(level: 2))
                 }
-            } else let implementingClass = getImplementingClass(for: type) {
+            } else if let implementingClass = getImplementingClass(for: type) {
                 // No registration values are specified, auto-generate registration
                 lines.append(contentsOf: generateClassRegistration(for: type, registeringClass: implementingClass))
             }
@@ -53,7 +53,7 @@ private extension AutoRegistering {
         let registrationName = registrationName(for: type)
         return types.classes.first(where: {
             $0.implements.contains(where: { $0.value == type })
-                && $0.withLowercaseFirst() == registrationName
+            && $0.name.withLowercaseFirst() == registrationName
         })
     }
 

--- a/Sources/Templates/AutoRegistering.swift
+++ b/Sources/Templates/AutoRegistering.swift
@@ -78,7 +78,7 @@ private extension AutoRegistering {
                     return nil
                 }
                 let label = parameter.argumentLabel ?? parameter.name
-                return "\(label): self.\(type.name.withLowercaseFirst().withoutLastCamelCasedPart())()"
+                return "\(label): self.\(registrationName)()"
             }
             guard canGenerateInit else {
                 return lines


### PR DESCRIPTION
Only use the exact match with the registration name derived from the protocol name for picking the implementation when auto-registering.