### PR TITLE
Auto-registerable skeletons

### DIFF
--- a/Sources/Templates/AutoRegisterable.swift
+++ b/Sources/Templates/AutoRegisterable.swift
@@ -69,6 +69,32 @@ enum AutoRegisterable {
         lines.append("}")
         lines.append(.emptyLine)
 
+        let sortedSkeletons: [(Type, Type)] = types.classes
+            .filter { $0.name.hasPrefix("Skeleton") }
+            .compactMap { classType in
+                guard let protocolType = sortedProtocols.first(where: { type in
+                    classType.implements.keys.contains(where: { $0.hasSuffix(type.name) })
+                }) else {
+                    return nil
+                }
+                return (classType, protocolType)
+            }
+            .sorted(by: { $0.0.name < $1.0.name })
+
+        if !sortedSkeletons.isEmpty {
+            lines.append("extension UseCasesContainer {")
+            lines.append("public static let skeleton: UseCasesContainer = {".indent())
+            lines.append("let container = UseCasesContainer()".indent(level: 2))
+            sortedSkeletons.forEach { (classType, protocolType) in
+                let registrationName = protocolType.name.withLowercaseFirst().withoutLastCamelCasedPart()
+                lines.append("container.\(registrationName).register { \(classType.name)() }".indent(level: 2))
+            }
+            lines.append("return container".indent(level: 2))
+            lines.append("}()".indent())
+            lines.append("}")
+            lines.append(.emptyLine)
+        }
+
         if let customContainerName, let propertyWrapperName = annotations.propertyWrapperName {
             lines.append("@propertyWrapper public struct \(propertyWrapperName)<T> {")
             lines.append("private var injected: Injected<T>".indent())

--- a/Sources/Templates/AutoRegisterable.swift
+++ b/Sources/Templates/AutoRegisterable.swift
@@ -69,7 +69,7 @@ enum AutoRegisterable {
         lines.append("}")
         lines.append(.emptyLine)
 
-        let sortedSkeletons: [(Type, Type)] = types.classes
+        let sortedSkeletons: [(Type, Type)] = (types.classes + types.structs)
             .filter { $0.name.hasPrefix("Skeleton") }
             .compactMap { classType in
                 guard let protocolType = sortedProtocols.first(where: { type in
@@ -82,9 +82,9 @@ enum AutoRegisterable {
             .sorted(by: { $0.0.name < $1.0.name })
 
         if !sortedSkeletons.isEmpty {
-            lines.append("extension \(customContainerName) {")
-            lines.append("public static let skeleton: \(customContainerName) = {".indent())
-            lines.append("let container = \(customContainerName)()".indent(level: 2))
+            lines.append("extension \(containerName) {")
+            lines.append("public static let skeleton: \(containerName) = {".indent())
+            lines.append("let container = \(containerName)()".indent(level: 2))
             sortedSkeletons.forEach { (classType, protocolType) in
                 let registrationName = protocolType.name.withLowercaseFirst().withoutLastCamelCasedPart()
                 lines.append("container.\(registrationName).register { \(classType.name)() }".indent(level: 2))

--- a/Sources/Templates/AutoRegisterable.swift
+++ b/Sources/Templates/AutoRegisterable.swift
@@ -82,9 +82,9 @@ enum AutoRegisterable {
             .sorted(by: { $0.0.name < $1.0.name })
 
         if !sortedSkeletons.isEmpty {
-            lines.append("extension UseCasesContainer {")
-            lines.append("public static let skeleton: UseCasesContainer = {".indent())
-            lines.append("let container = UseCasesContainer()".indent(level: 2))
+            lines.append("extension \(customContainerName) {")
+            lines.append("public static let skeleton: \(customContainerName) = {".indent())
+            lines.append("let container = \(customContainerName)()".indent(level: 2))
             sortedSkeletons.forEach { (classType, protocolType) in
                 let registrationName = protocolType.name.withLowercaseFirst().withoutLastCamelCasedPart()
                 lines.append("container.\(registrationName).register { \(classType.name)() }".indent(level: 2))


### PR DESCRIPTION
Automatically add skeleton container based on classes with a name starting with `Skeleton`, that implement one of the auto-registerable types.