### PR TITLE
Property wrapper Sendable conformance

### DIFF
--- a/Sources/Templates/AutoRegisterable.swift
+++ b/Sources/Templates/AutoRegisterable.swift
@@ -162,6 +162,8 @@ enum AutoRegisterable {
             lines.append("}".indent())
             lines.append("}")
             lines.append(.emptyLine)
+            lines.append("extension \(propertyWrapperName): @unchecked Sendable where T: Sendable { }")
+            lines.append(.emptyLine)
         }
 
         return lines.joined(separator: .newLine) + .newLine


### PR DESCRIPTION
Add `Sendable` conformance for Factory container property wrappers where injected is `Sendable`.