### PR TITLE
Add Actor conformance check

### DIFF
--- a/Sources/Templates/Extensions/Protocol+Extension.swift
+++ b/Sources/Templates/Extensions/Protocol+Extension.swift
@@ -44,7 +44,7 @@ private extension Protocol {
     }
 
     var mockType: String {
-        if based.contains(where: { $0.key == "AnyActor"}) {
+        if based.contains(where: { $0.key == "AnyActor" || $0.key == "Actor" }) {
             return "actor"
         }
         // If we have a method that returns `Self` we must declare the class final


### PR DESCRIPTION
There was a `AnyActor` conformance check, but that is deprecated for a while now
https://developer.apple.com/documentation/swift/anyactor

I added an additional `Actor` conformance check to properly create mock Actors