### PR TITLE
Support unnamed parameters

### DIFF
--- a/Sources/MockDeclarations/MockModels.swift
+++ b/Sources/MockDeclarations/MockModels.swift
@@ -87,3 +87,18 @@ struct MockModelWithOpaqueTypes {
     let closureWithOpagueReturnType: () -> any OpaqueType
     let closureWithOptionalOpagueReturnType: () -> (any OpaqueType)?
 }
+
+// sourcery: AutoStubbable
+struct MockUnnamedExternalParameter {
+
+    let string: String
+    let secondString: String
+
+    init(
+        _ firstValue: String,
+        secondValue: String
+    ) {
+        self.string = firstValue
+        self.secondString = secondValue
+    }
+}

--- a/Sources/Templates/Extensions/Type+Extension.swift
+++ b/Sources/Templates/Extensions/Type+Extension.swift
@@ -57,15 +57,15 @@ private extension Type {
         initParameters.append(contentsOf: implicitlyUnwrappedVariables.map { $0.generateInitAssignment(types: types, annotations: annotations).indent(level: 2) })
         lines.append(initParameters.joined(separator: "," + .newLine))
         lines.append(") -> \(name)\(method.isFailableInitializer ? "?" : "") {".indent())
-        let parameterNames = method.parameters.map { parameter in
-            parameter.argumentLabel ?? parameter.name
-        }
-        lines.append(generateStubbableInit(parameterNames: parameterNames))
+        lines.append(generateStubbableInit(methodParameters: method.parameters))
         lines.append("}".indent())
         return lines
     }
 
-    func generateStubbableInit(parameterNames: [String]) -> String {
+    func generateStubbableInit(methodParameters: [MethodParameter]) -> String {
+        let parameterNames = methodParameters.map {
+            $0.argumentLabel ?? $0.name
+        }
         let implicitlyUnwrappedVariables = storedVariables.filter { $0.isImplicitlyUnwrappedOptional }
         let containsImplicitlyUnwrappedOptionals = !implicitlyUnwrappedVariables.isEmpty
 
@@ -81,7 +81,14 @@ private extension Type {
         }
         lines.append(objectInit.indent(level: 2))
 
-        let parameterLines = parameterNames.map { "\($0): \($0)".indent(level: 3) }
+        let parameterLines = methodParameters.map {
+            if let argumentLabel = $0.argumentLabel {
+                "\(argumentLabel): \(argumentLabel)".indent(level: 3)
+            } else {
+                "\($0.name)".indent(level: 3)
+            }
+        }
+
         lines.append(parameterLines.joined(separator: "," + .newLine))
         if !parameterLines.isEmpty {
             lines.append(")".indent(level: 2))

--- a/Tests/TemplateTests/AutoStubbable.generated.swift
+++ b/Tests/TemplateTests/AutoStubbable.generated.swift
@@ -149,4 +149,16 @@ internal extension MockModelWithStubbablePropertyWithMultipleInitDeclaration {
     }
 }
 
+internal extension MockUnnamedExternalParameter {
+    static func stub(
+        firstValue: String = "",
+        secondValue: String = ""
+    ) -> MockUnnamedExternalParameter {
+        MockUnnamedExternalParameter(
+            firstValue,
+            secondValue: secondValue
+        )
+    }
+}
+
 // swiftlint:disable all


### PR DESCRIPTION
Added support for unnamed init parameters.

Fixing this issue: https://github.com/jimmya/sourcery-templates/issues/29
