### PR TITLE
Created AutoRegister annotation to register multiple implementations to the same AutoRegisterable protocol

### DIFF
--- a/Sources/Templates/AutoMockable.swift
+++ b/Sources/Templates/AutoMockable.swift
@@ -104,6 +104,11 @@ enum AutoMockable {
                     let registrationName = nameAndValue[0]
                     result.append((registrationName, mockName))
                 }
+            } else if let autoRegisterTypes = type.autoRegisterTypes {
+                autoRegisterTypes.forEach {
+                    let registrationName = $0.name.withLowercaseFirst()
+                    result.append((registrationName, mockName))
+                }
             } else {
                 let registrationName = type.name.withLowercaseFirst().withoutLastCamelCasedPart()
                 result.append((registrationName, mockName))

--- a/Sources/Templates/AutoRegisterable.swift
+++ b/Sources/Templates/AutoRegisterable.swift
@@ -52,12 +52,16 @@ enum AutoRegisterable {
         sortedProtocols.forEach { type in
             if let registrationValues = type.registrationValues {
                 // If the registration values are specified we can use the regular `Factory`
-            	let nameAndValuePairs = registrationValues.components(separatedBy: ",")
+                let nameAndValuePairs = registrationValues.components(separatedBy: ",")
                 nameAndValuePairs.forEach { pair in
                     let nameAndValue = pair.components(separatedBy: "=")
                     guard nameAndValue.count == 2 else { return }
                     let registrationName = nameAndValue[0]
                     addFactoryRegistration(to: &lines, registrationName: registrationName, typeName: type.name, scope: type.factoryScope)
+                }
+            } else if let autoRegisterTypes = type.autoRegisterTypes {
+                autoRegisterTypes.forEach {
+                    addFactoryRegistration(to: &lines, registrationName: $0.name.withLowercaseFirst(), typeName: type.name, scope: type.factoryScope)
                 }
             } else {
                 let initMethods = type.methods.filter(\.isInitializer)

--- a/Sources/Templates/AutoRegistering.swift
+++ b/Sources/Templates/AutoRegistering.swift
@@ -21,13 +21,19 @@ enum AutoRegistering {
                 lines.append("\(registrationName).register { \(registrationValue) }".indent(level: 2))
             } else if let registrationValues = type.registrationValues {
                 // If multiple registration name-value pairs are specified we register them all
-            	let nameAndValuePairs = registrationValues.components(separatedBy: ",")
+                let nameAndValuePairs = registrationValues.components(separatedBy: ",")
                 nameAndValuePairs.forEach { pair in
                     let nameAndValue = pair.components(separatedBy: "=")
                     guard nameAndValue.count == 2 else { return }
                     let registrationName = nameAndValue[0]
                     let registrationValue = nameAndValue[1]
                     lines.append("\(registrationName).register { \(registrationValue) }".indent(level: 2))
+                }
+            } else if let autoRegisterTypes = type.autoRegisterTypes {
+                autoRegisterTypes.forEach {
+                    let registrationName = $0.name.withLowercaseFirst()
+                    let registrationValue = $0.name
+                    lines.append("\(registrationName).register { \(registrationValue)() }".indent(level: 2))
                 }
             } else if let implementingType = getImplementingType(for: type) {
                 // No registration values are specified, auto-generate registration

--- a/Sources/Templates/Extensions/Annotated+Extension.swift
+++ b/Sources/Templates/Extensions/Annotated+Extension.swift
@@ -13,6 +13,10 @@ extension Annotated {
         annotations["AutoRegisterable"] as? Int == 1
     }
 
+    var isAutoRegister: Bool {
+        annotations["AutoRegister"] as? Int == 1
+    }
+
     var registrationValue: String? {
         annotations["registrationValue"] as? String
     }

--- a/Sources/Templates/Extensions/Type+Extension.swift
+++ b/Sources/Templates/Extensions/Type+Extension.swift
@@ -6,6 +6,13 @@ extension Type {
         methods.filter { ($0.isInitializer || $0.isFailableInitializer) && !$0.isConvenienceInitializer }
     }
 
+    var autoRegisterTypes: [Type]? {
+        let autoRegisterTypes = types.all.filter {
+            $0.implements.contains(where: { $0.value == self }) && $0.isAutoRegister
+        }
+        return autoRegisterTypes.isEmpty ? nil : autoRegisterTypes
+    }
+
     func generateStub(types: Types, annotations: Annotations) -> [String] {
         var lines: [String] = []
         lines.append("\(accessLevel) extension \(name) {")


### PR DESCRIPTION
This PR introduces support for annotating protocol implementations with AutoRegister, enabling multiple implementations of the same protocol to be seamlessly registered in the container.

### Example Usage
Given the following protocol and implementations:

```swift
// sourcery: AutoMockable
protocol GetLintsUseCaseProtocol {}

// sourcery: AutoRegister
struct GetRecommendationLintsUseCase: GetLintsUseCaseProtocol {}

// sourcery: AutoRegister
struct GetDynamicLintsUseCase: GetLintsUseCaseProtocol {}

```

The following will be automatically added to the container:

```swift
public var getRecommendationLintsUseCase: Factory<GetLintsUseCaseProtocol> {
    self { fatalError("GetLintsUseCaseProtocol not registered") }
}
public var getDynamicLintsUseCase: Factory<GetLintsUseCaseProtocol> {
    self { fatalError("GetLintsUseCaseProtocol not registered") }
}
```

Additionally, the implementations will be auto-registered:

```swift
getRecommendationLintsUseCase.register { GetRecommendationLintsUseCase() }
getDynamicLintsUseCase.register { GetDynamicLintsUseCase() }
```

Their corresponding mocks will also be added to the Mock Container:

```swift 
public lazy var getRecommendationLintsUseCase = MockGetLintsUseCaseProtocol()
public lazy var getDynamicLintsUseCase = MockGetLintsUseCaseProtocol()

public init(
    getRecommendationLintsUseCase: MockGetLintsUseCaseProtocol? = nil,
    getDynamicLintsUseCase: MockGetLintsUseCaseProtocol? = nil
) {

    if let getRecommendationLintsUseCase { self.getRecommendationLintsUseCase = getRecommendationLintsUseCase }
    if let getDynamicLintsUseCase { self. getDynamicLintsUseCase = getDynamicLintsUseCase }

```