### PR TITLE
Made Registerable shared container constant to support swift6 concurrency

### DIFF
--- a/Sources/Templates/AutoMockable.swift
+++ b/Sources/Templates/AutoMockable.swift
@@ -12,7 +12,7 @@ enum AutoMockable {
             .sorted(by: { $0.value < $1.value })
 
         sortedContainerMappings?.forEach { module, containerName in
-            lines.append("public final class \(containerName)Mocks {")
+            lines.append("public final class \(containerName)Mocks: @unchecked Sendable {")
             lines.append(.emptyLine)
 
             let sortedExtensionVariables = types.extensions

--- a/Sources/Templates/AutoRegisterable.swift
+++ b/Sources/Templates/AutoRegisterable.swift
@@ -13,8 +13,8 @@ enum AutoRegisterable {
         let customContainerName = annotations.containerName
         if let customContainerName {
             lines.append("public final class \(customContainerName): SharedContainer {")
-            lines.append("public static var shared = \(customContainerName)()".indent())
-            lines.append("public var manager = ContainerManager()".indent())
+            lines.append("public static let shared = \(customContainerName)()".indent())
+            lines.append("public let manager = ContainerManager()".indent())
 
             let sortedPreviews: [(Type, Type)] = (types.classes + types.structs)
                 .filter { $0.name.hasPrefix("Preview") }


### PR DESCRIPTION
This fixes the following swift 6 errors:

- Static property 'shared' is not concurrency-safe because it is nonisolated global shared mutable state
- Stored property 'manager' of 'Sendable'-conforming class '...Container' is mutable