### PR TITLE
Make Mocks of Sendable Protocols @unchecked Sendable

### DIFF
--- a/Sources/Templates/Extensions/Protocol+Extension.swift
+++ b/Sources/Templates/Extensions/Protocol+Extension.swift
@@ -34,8 +34,13 @@ extension Protocol {
 private extension Protocol {
     /// Returns `class DefaultProtocolNameMock: InheritedTypes {`
     func generateClassDeclaration(annotations: Annotations) -> String {
+        var sendableNaming = ""
+        if self.inheritedTypes.contains(where: { $0 == "Sendable" }) {
+            sendableNaming = ", @unchecked Sendable"
+        }
+
         let mockNaming = annotations.mockName(typeName: name)
-        return "\(accessLevel) \(mockType) \(mockNaming): \(mockInheritedTypes) {"
+        return "\(accessLevel) \(mockType) \(mockNaming): \(mockInheritedTypes)\(sendableNaming) {"
     }
 
     var mockInheritedTypes: String {


### PR DESCRIPTION
Make Mocks of Sendable Protocols `@unchecked Sendable`

The following type: 
`protocol NetworkManagerProtocol: Sendable`

Will generate:

`public class MockNetworkManagerProtocol: NetworkManagerProtocol, @unchecked Sendable`
