### PR TITLE
Added support for nonisolated mock variables.

### DIFF
--- a/Sources/Templates/Extensions/Variable+Extension.swift
+++ b/Sources/Templates/Extensions/Variable+Extension.swift
@@ -42,16 +42,25 @@ private extension Variable {
             returnTypeName = typeName.isOptional ? "(\(closureSignature))?" : closureSignature
         }
 
-        return """
-            \(accessLevel) var invoked\(capitalizedName)Setter = false
-            \(accessLevel) var invoked\(capitalizedName)SetterCount = 0
-            \(accessLevel) var invoked\(capitalizedName): \(invokedObjectType)
-            \(accessLevel) var invoked\(capitalizedName)List: [\(listTypeName)] = []
-            \(accessLevel) var invoked\(capitalizedName)Getter = false
-            \(accessLevel) var invoked\(capitalizedName)GetterCount = 0
-            \(accessLevel) var stubbed\(capitalizedName): \(stubbedObjectType)
+        let isNonisolated = modifiers.contains {
+            $0.name == "nonisolated"
+        }
 
-            \(accessLevel) var \(name): \(returnTypeName) {
+        var isolationLevel = ""
+        if isNonisolated {
+            isolationLevel = "nonisolated(unsafe) "
+        }
+
+        return """
+            \(accessLevel) \(isolationLevel)var invoked\(capitalizedName)Setter = false
+            \(accessLevel) \(isolationLevel)var invoked\(capitalizedName)SetterCount = 0
+            \(accessLevel) \(isolationLevel)var invoked\(capitalizedName): \(invokedObjectType)
+            \(accessLevel) \(isolationLevel)var invoked\(capitalizedName)List: [\(listTypeName)] = []
+            \(accessLevel) \(isolationLevel)var invoked\(capitalizedName)Getter = false
+            \(accessLevel) \(isolationLevel)var invoked\(capitalizedName)GetterCount = 0
+            \(accessLevel) \(isolationLevel)var stubbed\(capitalizedName): \(stubbedObjectType)
+
+            \(accessLevel) \(isolationLevel)var \(name): \(returnTypeName) {
                 get {
                     invoked\(capitalizedName)Getter = true
                     invoked\(capitalizedName)GetterCount += 1
@@ -86,12 +95,21 @@ private extension Variable {
             returnTypeName = typeName.isOptional ? "(\(closureSignature))?" : closureSignature
         }
 
-        return """
-            \(accessLevel) var invoked\(capitalizedName)Getter = false
-            \(accessLevel) var invoked\(capitalizedName)GetterCount = 0
-            \(accessLevel) var stubbed\(capitalizedName): \(stubbedObjectType)
+        let isNonisolated = modifiers.contains {
+            $0.name == "nonisolated"
+        }
 
-            \(accessLevel) var \(name): \(returnTypeName) {
+        var isolationLevel = ""
+        if isNonisolated {
+            isolationLevel = "nonisolated(unsafe) "
+        }
+
+        return """
+            \(accessLevel) \(isolationLevel)var invoked\(capitalizedName)Getter = false
+            \(accessLevel) \(isolationLevel)var invoked\(capitalizedName)GetterCount = 0
+            \(accessLevel) \(isolationLevel)var stubbed\(capitalizedName): \(stubbedObjectType)
+
+            \(accessLevel) \(isolationLevel)var \(name): \(returnTypeName) {
                 invoked\(capitalizedName)Getter = true
                 invoked\(capitalizedName)GetterCount += 1
                 return stubbed\(capitalizedName)

--- a/Sources/Templates/Extensions/Variable+Extension.swift
+++ b/Sources/Templates/Extensions/Variable+Extension.swift
@@ -5,6 +5,10 @@ extension Variable {
         defaultValue != nil
     }
 
+    var isNonIsolated: Bool { 
+        modifiers.contains { $0.name == "nonisolated" }
+    }
+
     func generateMock(types: Types, accessLevel: String, annotations: Annotations) -> String {
         isMutable ? generateMutableMock(types: types, accessLevel: accessLevel, annotations: annotations) : generateComputedMock(types: types, accessLevel: accessLevel, annotations: annotations)
     }
@@ -42,12 +46,8 @@ private extension Variable {
             returnTypeName = typeName.isOptional ? "(\(closureSignature))?" : closureSignature
         }
 
-        let isNonisolated = modifiers.contains {
-            $0.name == "nonisolated"
-        }
-
         var isolationLevel = ""
-        if isNonisolated {
+        if isNonIsolated {
             isolationLevel = "nonisolated(unsafe) "
         }
 
@@ -95,12 +95,8 @@ private extension Variable {
             returnTypeName = typeName.isOptional ? "(\(closureSignature))?" : closureSignature
         }
 
-        let isNonisolated = modifiers.contains {
-            $0.name == "nonisolated"
-        }
-
         var isolationLevel = ""
-        if isNonisolated {
+        if isNonIsolated {
             isolationLevel = "nonisolated(unsafe) "
         }
 


### PR DESCRIPTION
Added support for nonisolated mock variables.

```swift
public protocol CoolProtocol: Actor {
    nonisolated var something: String { get }
}
```

Will generate:

```swift
public actor MockCoolProtocol: CoolProtocol {

    public nonisolated(unsafe) var invokedSomethingGetter = false
    public nonisolated(unsafe) var invokedSomethingGetterCount = 0
    public nonisolated(unsafe) var stubbedSomething: String

    public nonisolated(unsafe) var something: String {
        invokedSomethingGetter = true
        invokedSomethingGetterCount += 1
        return stubbedSomething
    }
}
```

