### PR TITLE
Swift Parallel testing support 

### DIFF
--- a/Sources/Templates/AutoMockable.swift
+++ b/Sources/Templates/AutoMockable.swift
@@ -76,6 +76,16 @@ enum AutoMockable {
             lines.append("}".indent())
             lines.append("}")
             lines.append(.emptyLine)
+
+            if annotations.testingFrameworkTypes.contains(.swiftTesting) {
+                lines.append("extension Trait where Self == ContainerTrait<\(containerName)> {");
+                lines.append("public static var \(containerName.withLowercaseFirst()): ContainerTrait<\(containerName)> {".indent());
+                lines.append(".init(shared: \(containerName).$shared, container: \(containerName)())".indent(level: 2));
+                lines.append("}".indent());
+                lines.append("}");
+
+                lines.append(.emptyLine)
+            }
         }
 
         let sortedProtocols = types.protocols

--- a/Sources/Templates/AutoRegisterable.swift
+++ b/Sources/Templates/AutoRegisterable.swift
@@ -13,7 +13,7 @@ enum AutoRegisterable {
         let customContainerName = annotations.containerName
         if let customContainerName {
             lines.append("public final class \(customContainerName): SharedContainer {")
-            lines.append("public static let shared = \(customContainerName)()".indent())
+            lines.append("@TaskLocal public static var shared = \(customContainerName)()".indent())
             lines.append("public let manager = ContainerManager()".indent())
 
             let sortedPreviews: [(Type, Type)] = (types.classes + types.structs)


### PR DESCRIPTION
# Summary

This PR adds support for Swift Parallel Testing by leveraging Swift 6.1’s ability to define custom test scopes.

# Details

- Shared containers are now annotated with @TaskLocal to ensure test isolation in parallel execution.
- Introduced a custom TestingTrait for each container type. Example:

```swift
extension Trait where Self == ContainerTrait<UseCaseContainer> {
    public static var useCaseContainer: ContainerTrait<UseCaseContainer> {
        .init(shared: UseCaseContainer.$shared, container: UseCaseContainer())
    }
}
```

# Usage

Each test will now receive its own instance of the underlying dependency container:

```swift
@Suite(.useCaseContainer)
class SomeViewModelTests {

    var mockUseCaseContainer = UseCaseContainerMocks()

   @Test
   func test1() { 
       // New Container
    }

   @Test
   func test2() { 
       // New Container
    }

```
