### PR TITLE
Make AutoRegistering conformance retroactive

### DIFF
--- a/Sources/Templates/AutoRegistering.swift
+++ b/Sources/Templates/AutoRegistering.swift
@@ -7,7 +7,7 @@ enum AutoRegistering {
         lines.append("")
 
         let containerName = annotations.containerName ?? "Container"
-        lines.append("extension \(containerName): AutoRegistering {")
+        lines.append("extension \(containerName): @retroactive AutoRegistering {")
         lines.append("public func autoRegister() {".indent())
 
         let sortedProtocols = types.protocols

--- a/Sources/Templates/AutoRegistering.swift
+++ b/Sources/Templates/AutoRegistering.swift
@@ -7,7 +7,8 @@ enum AutoRegistering {
         lines.append("")
 
         let containerName = annotations.containerName ?? "Container"
-        lines.append("extension \(containerName): @retroactive AutoRegistering {")
+        let retroactiveConformance = annotations.retroactiveConformance ?? false
+        lines.append("extension \(containerName): \(retroactiveConformance ? "@retroactive " : "")AutoRegistering {")
         lines.append("public func autoRegister() {".indent())
 
         let sortedProtocols = types.protocols

--- a/Sources/Templates/Extensions/Annotations+Extension.swift
+++ b/Sources/Templates/Extensions/Annotations+Extension.swift
@@ -44,6 +44,10 @@ extension Annotations {
         self["containerName"] as? String
     }
 
+    var retroactiveConformance: Bool? {
+        self["retroactiveConformance"] as? Bool
+    }
+
     var propertyWrapperName: String? {
         self["propertyWrapperName"] as? String
     }


### PR DESCRIPTION
To suppress the following warning:

> Extension declares a conformance of imported type 'XxxxxxxxxContainer' to imported protocol 'AutoRegistering'; this will not behave correctly if the owners of 'XxxxxxxxxProtocols' introduce this conformance in the future